### PR TITLE
fix: correct calc to uT based on res and gain.

### DIFF
--- a/Adafruit_MLX90395.cpp
+++ b/Adafruit_MLX90395.cpp
@@ -56,8 +56,10 @@ bool Adafruit_MLX90395::_init(void) {
   _gain = getGain();
   if (_gain == 8) { // default high field gain
     _uTLSB = 7.14;
+    _gain_default = 8;
   } else {
     _uTLSB = 2.5; // medium field gain
+    _gain_default = 9;
   }
 
   _resolution = getResolution();
@@ -121,14 +123,15 @@ bool Adafruit_MLX90395::readMeasurement(float *x, float *y, float *z) {
   yi = (rx[4] << 8) | rx[5];
   zi = (rx[6] << 8) | rx[7];
 
-  *x = xi;
-  *y = yi;
-  *z = zi;
+  // makes a resolution correction, see DS 18.6. Sensitivity for details
+  *x = (float)(xi << _resolution);
+  *y = (float)(yi << _resolution);
+  *z = (float)(zi << _resolution);
 
-  // multiply by gain & LSB
-  *x *= gainMultipliers[_gain] * _uTLSB;
-  *y *= gainMultipliers[_gain] * _uTLSB;
-  *z *= gainMultipliers[_gain] * _uTLSB;
+  // multiply by current gain setting & LSB/uT
+  *x *= _uTLSB * gainMultipliers[_gain_default] / gainMultipliers[_gain];
+  *y *= _uTLSB * gainMultipliers[_gain_default] / gainMultipliers[_gain];
+  *z *= _uTLSB * gainMultipliers[_gain_default] / gainMultipliers[_gain];
 
   return true;
 }

--- a/Adafruit_MLX90395.h
+++ b/Adafruit_MLX90395.h
@@ -75,6 +75,7 @@ private:
 
   mlx90393_res_t _resolution = MLX90395_RES_17;
   uint8_t _gain = 0;
+  uint8_t _gain_default = 0;
   float _uTLSB = 0;
   int32_t _sensorID = 90395;
 };


### PR DESCRIPTION
- the resolution and the gain settings of the sensor is properly accounted with fix I propose.
- the info specified in the datasheet not completely clear. And it takes a while from my side contacting the Melexis support to find out, how the gain should be accounted.

It should be done as follows:
The recalculation factor/formula for the magnetic data measurements is dependent on the two sensitivity settings: **GainSel** and **[ResX, ResY, ResZ]**.
To perform the calculation from ADC Counts to uT follow the steps:

1. Resolution Correction.
 
        Mag_X_ADC_ResCorr = Mag_X_ADC << ResX;
        Mag_Y_ADC_ResCorr = Mag_Y_ADC << ResY;
        Mag_Z_ADC_ResCorr = Mag_Z_ADC << ResZ;
            
    ```<<``` - state for the left arithmetic bit shift (1-bit left shift -> multiplication by 2).
        Note. Make sure no variable overflow is possible during the left bit shift operation.

2. ADC Counts -> uT calculation (uT is µT).
Here, the correct setting for GainSel should be accounted.
In the DS 16.1. Medium-Field Variant, page 17 mentioned: *Sensitivity X-, Y-, Z-axis is **2.5 uT/LSB16** or 400 LSB16/mT*.
This is true for the default GainSel = 9 setting, which is: ```gain_gainSel_9_default = 0.125```.
However, in case the altered gain is used, then the relative change in the sensitivity should be taken into account.
E.g. GainSel = 7 -> ```gain_gainSel_7 = 1.0``` -> The sensitivity is increased in 8 times comparing to default GainSel:
```1.0 / 0.125 = 8```.

Generally, the uTinLSB factor could be expressed as:
        ```uTinLSB = uTinLSB_default * gain_gainSel_9_default / gain_current ```
        
        For the specific case, GainSel = 7, the formula will be:
        
        uTinLSB = 2.5 * 0.125 / 1.0;
        uTinLSB = 2.5 / 8;
        uTinLSB = 0.3125;
        Mag_X_uT = uTinLSB * Mag_X_ADC_ResCorr;
        Mag_X_uT = uTinLSB * Mag_X_ADC_ResCorr;
        Mag_Z_uT = uTinLSB * Mag_X_ADC_ResCorr;
        